### PR TITLE
Add tool-panel right border

### DIFF
--- a/stylesheets/panels.less
+++ b/stylesheets/panels.less
@@ -20,6 +20,7 @@
     box-shadow: inset 0 1px 0 @background-color-highlight;
   }
 
+  &.panel-right,
   &.panel-left {
     border-right: 1px solid @tool-panel-border-color;
   }


### PR DESCRIPTION
The tree-view module was updated with support to show the panel on the right side.
