### PR TITLE
Get the description back

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "atom-dark-ui-slim",
   "theme": "ui",
   "version": "0.47.1",
-  "description": "Default dark theme for interface components",
+  "description": "A slim version of atom-dark-ui",
   "license": "MIT",
   "repository": "https://github.com/bmathews/atom-dark-ui-slim",
   "engines": {


### PR DESCRIPTION
Description and version were lost with the upstream sync https://github.com/bmathews/atom-dark-ui-slim/commit/a5535ce753884116d51be0b4e79fada65692d6a1

Got the description back. The version might have to stay like this now :crying_cat_face: 
